### PR TITLE
Handle multiple configurations for the same integration.

### DIFF
--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -145,20 +145,32 @@ export default class Analytics extends Emitter {
     this._options(options);
     this._readied = false;
 
+    const multipleConfigurationRegex = /^([a-zA-Z0-9\-_]+)\[(\d+)\]$/;
+
     for (const name in settings) {
       if (settings.hasOwnProperty(name)) {
+
+        let integrationName = name;
+
+        // if the name is in form some-name[<numeric>] it's because there is multiple
+        // time the same integration with different options
+        const configurationMultiple = multipleConfigurationRegex.exec(name);
+        if (configurationMultiple !== null) {
+          integrationName = configurationMultiple[1];
+        }
+
         // clean unknown integrations from settings
-        if (!this.Integrations[name]) {
+        if (!this.Integrations[integrationName]) {
           delete settings[name];
           continue;
         }
 
         // add integrations
         const opts = clone(settings[name]);
-        const Integration = this.Integrations[name];
+        const Integration = this.Integrations[integrationName];
         const integration = new Integration(opts);
         this.log("initialize %o - %o", name, opts);
-        this.add(integration);
+        this.add(integration, name);
       }
     }
 
@@ -227,9 +239,10 @@ export default class Analytics extends Emitter {
    * Add an integration.
    *
    * @param {Integration} integration
+   * @param name name to give to the integration instance, by default integration.name
    */
-  add(integration) {
-    this._integrations[integration.name] = integration;
+  add(integration, name = integration.name) {
+    this._integrations[name] = integration;
     return this;
   }
 


### PR DESCRIPTION
Allow to use settings in the format 
```
tag-commander[0] => {...}
tag-commander[1] => {...}
```
To be able to add multiple instances of the same integration